### PR TITLE
feat(auth-guard): add allowAdd, editor, general, and user guards

### DIFF
--- a/backend-nest/src/auth-guard/general.guard.ts
+++ b/backend-nest/src/auth-guard/general.guard.ts
@@ -1,0 +1,56 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Injectable,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectModel } from '@nestjs/mongoose';
+import { Request } from 'express';
+import { Model } from 'mongoose';
+import { Token } from './token.schema';
+import { UserService } from 'src/user/user.service';
+import { AdminService } from 'src/admin/admin.service';
+import { log } from 'console';
+
+@Injectable()
+export class GeneralGuard implements CanActivate {
+  constructor(
+    private jwtService: JwtService,
+    @InjectModel(Token.name) private tokenModel: Model<Token>,
+    private adminService: AdminService,
+    private userService: UserService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const authHeader = request.headers.authorization;
+
+    if (!authHeader) return false;
+    const token = authHeader.split(' ')[1];
+
+    if (!token)
+      throw new HttpException('Token not found', HttpStatus.UNAUTHORIZED);
+
+    const payload = await this.jwtService.verifyAsync(token);
+
+    const isValid: { token: string } | null = await this.tokenModel.findOne(
+      {
+        token,
+      },
+      { token: 1, _id: 0 },
+    );
+
+    if (!(isValid?.token === token) || (!payload && false))
+      throw new HttpException('Invalid token', HttpStatus.UNAUTHORIZED);
+
+    request[payload.adminId ? 'admin' : 'user'] = payload;
+
+    const isUser = await this.userService.userExists(payload.userId);
+
+    const isAdmin = await this.adminService.adminExists(payload.adminId);
+
+    return !!(isUser[1] || isAdmin[1]);
+  }
+}

--- a/backend-nest/src/auth-guard/user/allow-add.guard.ts
+++ b/backend-nest/src/auth-guard/user/allow-add.guard.ts
@@ -1,0 +1,67 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  forwardRef,
+  HttpException,
+  HttpStatus,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectModel } from '@nestjs/mongoose';
+import { Request } from 'express';
+import { Token } from '../token.schema';
+import { Model } from 'mongoose';
+import { WorkspaceUserService } from 'src/workspace-user/workspace-user.service';
+
+@Injectable()
+export class AllowAddGuard implements CanActivate {
+  constructor(
+    private jwtService: JwtService,
+    @InjectModel(Token.name) private tokenModel: Model<Token>,
+    private workspaceUserService: WorkspaceUserService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const authHeader = request.headers.authorization;
+
+    if (!authHeader) return false;
+
+    const token = authHeader.split(' ')[1];
+
+    if (!token)
+      throw new HttpException('Token not found', HttpStatus.UNAUTHORIZED);
+
+    try {
+      const payload = await this.jwtService.verifyAsync(token);
+      const isValid: { token: string } | null = await this.tokenModel.findOne(
+        {
+          userId: payload.userId,
+        },
+        { token: 1, _id: 0 },
+      );
+
+      if (payload.adminId) return true;
+
+      if (!(isValid?.token === token) || !payload)
+        throw new HttpException('Invalid token', HttpStatus.UNAUTHORIZED);
+
+
+      const workspaceId =
+        request.body.workspaceId || request.params.workspaceId;
+
+      const workspaceUser = await this.workspaceUserService.getWorkspaceUser(
+        payload.userId,
+        workspaceId,
+      );
+
+      return !!workspaceUser?.permissions.allowAdd;
+    } catch {
+      throw new HttpException(
+        'Invalid or expired token',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+  }
+}

--- a/backend-nest/src/auth-guard/user/editor.guard.ts
+++ b/backend-nest/src/auth-guard/user/editor.guard.ts
@@ -1,0 +1,56 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Injectable,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectModel } from '@nestjs/mongoose';
+import { Request } from 'express';
+import { Token } from '../token.schema';
+import { Model } from 'mongoose';
+import { WorkspaceUserService } from 'src/workspace-user/workspace-user.service';
+
+@Injectable()
+export class EditorGuard implements CanActivate {
+  constructor(
+    private jwtService: JwtService,
+    @InjectModel(Token.name) private tokenModel: Model<Token>,
+    private workspaceUserService: WorkspaceUserService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const authHeader = request.headers.authorization;
+
+    if (!authHeader) return false;
+
+    const token = authHeader.split(' ')[1];
+
+    if (!token)
+      throw new HttpException('Token not found', HttpStatus.UNAUTHORIZED);
+
+    const payload = await this.jwtService.verifyAsync(token);
+
+    const isValid: { token: string } | null = await this.tokenModel.findOne(
+      {
+        userId: payload.userId,
+      },
+      { token: 1, _id: 0 },
+    );
+
+    if (!(isValid?.token === token) || !payload)
+      throw new HttpException('Invalid token', HttpStatus.UNAUTHORIZED);
+
+    const workspaceId = request.body.workspaceId || request.params.workspaceId;
+
+    const workspaceUser = await this.workspaceUserService.getWorkspaceUser(
+      payload.userId,
+      workspaceId,
+    );
+    request['user'] = payload;
+
+    return !!workspaceUser?.permissions.write;
+  }
+}

--- a/backend-nest/src/auth-guard/user/user.guard.ts
+++ b/backend-nest/src/auth-guard/user/user.guard.ts
@@ -1,0 +1,60 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { InjectModel } from '@nestjs/mongoose';
+import { Request } from 'express';
+import { Token } from '../token.schema';
+import { Model } from 'mongoose';
+import { UserService } from 'src/user/user.service';
+
+@Injectable()
+export class UserGuard implements CanActivate {
+  constructor(
+    private jwtService: JwtService,
+    @InjectModel(Token.name) private tokenModel: Model<Token>,
+    private userService: UserService,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<Request>();
+    const authHeader = request.headers.authorization;
+
+    if (!authHeader) return false;
+
+    const token = authHeader.split(' ')[1];
+
+    if (!token)
+      throw new HttpException('Token not found', HttpStatus.UNAUTHORIZED);
+
+    try {
+      const payload = await this.jwtService.verifyAsync(token);
+
+      const isValid: { token: string } | null = await this.tokenModel.findOne(
+        {
+          userId: payload.userId,
+        },
+        { token: 1, _id: 0 },
+      );
+
+      if (!(isValid?.token === token) || !payload)
+        throw new HttpException('Invalid token', HttpStatus.UNAUTHORIZED);
+
+      request['user'] = payload;
+
+      const isUser = await this.userService.userExists(payload.userId);
+
+      return !!isUser[1];
+    } catch {
+      throw new HttpException(
+        'Invalid or expired token',
+        HttpStatus.UNAUTHORIZED,
+      );
+    }
+  }
+}


### PR DESCRIPTION
-  `allowAdd` guard for workspace admin
-  `editor` guard to enforce editor-only access in workspace
-  `general` guard for shared user/admin access checks
-  `user` guard to restrict actions to workspace users
